### PR TITLE
change mapping of Ads client symbols to be a dict rather than a list

### DIFF
--- a/docs/explanations/dynamic-pdos.md
+++ b/docs/explanations/dynamic-pdos.md
@@ -182,8 +182,8 @@ async with CatioClient(target_ip="192.168.1.100") as client:
 
     # Symbols are keyed by device ID
     for device_id, symbols in all_symbols.items():
-        for symbol in symbols:
-            print(f"{symbol.name}: {symbol.type_name}")
+        for name, symbol in symbols.items():
+            print(f"{name}: {symbol.type_name}")
 ```
 
 ## Implementation in catio-terminals

--- a/docs/how-to/get-all-pdos-in-chain.md
+++ b/docs/how-to/get-all-pdos-in-chain.md
@@ -79,7 +79,7 @@ The YAML file includes **both** configurations, but only one will be active in T
 ```python
 # Query actual symbols for an EL1502
 symbols = await client.get_all_symbols()
-el1502_symbols = [s for s in symbols[device_id] if "EL1502" in s.name]
+el1502_symbols = [symbol for name, symbol in symbols[device_id].items() if "EL1502" in name]
 
 # Check which configuration is active
 has_per_channel = any("Channel 1" in s.name for s in el1502_symbols)
@@ -101,7 +101,7 @@ The TwinCAT project selects one format per channel. Both are defined in XML as o
 ```python
 # Query actual symbols for analog input terminals
 symbols = await client.get_all_symbols()
-ai_symbols = [s for s in symbols[device_id] if "AI" in s.name]
+ai_symbols = [s for name, symbol in symbols[device_id].items() if "AI" in name]
 
 # Determine which format is active
 has_standard = any("Standard" in s.name for s in ai_symbols)
@@ -130,7 +130,7 @@ Additionally, it has optional `RMB Status`, `RMB Timestamp`, and `RMB Control` P
 ```python
 # Query actual symbols for EL3356
 symbols = await client.get_all_symbols()
-el3356_symbols = [s for s in symbols[device_id] if "EL3356" in s.name]
+el3356_symbols = [s for name, symbol in symbols[device_id].items() if "EL3356" in name]
 
 # Determine which value format is active
 has_int32 = any("RMB Value (INT32)" in s.name for s in el3356_symbols)
@@ -159,8 +159,8 @@ has_control = any("RMB Control" in s.name for s in el3356_symbols)
 ```python
 # Query actual symbols for an EL3702
 symbols = await client.get_all_symbols()
-el3702_ch1 = [s for s in symbols[device_id]
-              if "EL3702" in s.name and "Ch1" in s.name and "Value" in s.name]
+el3702_ch1 = [s for name, symbol in symbols[device_id].items()
+              if "EL3702" in name and "Ch1" in name and "Value" in name]
 
 oversampling_factor = len(el3702_ch1)
 print(f"EL3702 configured for {oversampling_factor}x oversampling")
@@ -174,7 +174,7 @@ print(f"EL3702 configured for {oversampling_factor}x oversampling")
 ```python
 # Query actual symbols for an EL4732
 symbols = await client.get_all_symbols()
-el4732_symbols = [s for s in symbols[device_id] if "EL4732" in s.name and "Value" in s.name]
+el4732_symbols = [s for name, symbol in symbols[device_id].items() if "EL4732" in name and "Value" in name]
 
 # Count array elements to determine oversampling factor
 sample_count = len(el4732_symbols)
@@ -203,7 +203,7 @@ The XML defines 192 TxPDOs (48 per channel) covering all combinations!
 ```python
 # Query actual symbols for ELM3704
 symbols = await client.get_all_symbols()
-elm3704_symbols = [s for s in symbols[device_id] if "ELM3704" in s.name]
+elm3704_symbols = [s for name, symbol in symbols[device_id].items() if "ELM3704" in name]
 
 for ch in range(1, 5):
     ch_symbols = [s for s in elm3704_symbols if f"Channel {ch}" in s.name]
@@ -279,8 +279,8 @@ async with CatioClient(target_ip="192.168.1.100") as client:
 
     # Symbols are keyed by device ID
     for device_id, symbols in all_symbols.items():
-        for symbol in symbols:
-            print(f"{symbol.name}: {symbol.type_name} @ {symbol.index_group:#x}:{symbol.index_offset}")
+        for name, symbol in symbols.items():
+            print(f"{name}: {symbol.type_name} @ {symbol.index_group:#x}:{symbol.index_offset}")
 ```
 
 ## Recommendations

--- a/src/fastcs_catio/catio_connection.py
+++ b/src/fastcs_catio/catio_connection.py
@@ -176,7 +176,9 @@ class CATioStreamConnection:
         If the server configuration changes, this method should be called again.
         """
         await self.client.introspect_io_server()
-        self._notification_symbols = await self.client.get_all_symbols()
+        all_symbols = await self.client.get_all_symbols()
+        for device_id, symbols_dict in all_symbols.items():
+            self._notification_symbols[device_id] = list(symbols_dict.values())
 
     async def command(self, command: str, *args, **kwargs) -> None:
         """

--- a/src/fastcs_catio/catio_hardware.py
+++ b/src/fastcs_catio/catio_hardware.py
@@ -133,12 +133,17 @@ class EtherCATMasterController(CATioDeviceController):
                 ),
             )
 
-            # Map the FastCS attribute name to the symbol name used by ADS
+            # Map the FastCS channel attribute name to the symbol name used by ADS
             self.ads_name_map[f"InFrm{i}State"] = f"Inputs.Frm{i}State"
             self.ads_name_map[f"InFrm{i}WcState"] = f"Inputs.Frm{i}WcState"
             self.ads_name_map[f"InFrm{i}InpToggle"] = f"Inputs.Frm{i}InputToggle"
             self.ads_name_map[f"OutFrm{i}Ctrl"] = f"Outputs.Frm{i}Ctrl"
             self.ads_name_map[f"OutFrm{i}WcCtrl"] = f"Outputs.Frm{i}WcCtrl"
+
+        # Map the FastCS attribute name to the symbol name used by ADS
+        self.ads_name_map["InputsSlaveCount"] = "Inputs.SlaveCount"
+        self.ads_name_map["InputsDevState"] = "Inputs.DevState"
+        self.ads_name_map["OutputsDevCtrl"] = "Outputs.DevCtrl"
 
         attr_count = len(self.attributes) - initial_attr_count
         logger.debug(f"Created {attr_count} attributes for the controller {self.name}.")

--- a/tests/diagnose_hardware.py
+++ b/tests/diagnose_hardware.py
@@ -17,7 +17,6 @@ import argparse
 import asyncio
 import logging
 import sys
-from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -105,12 +104,12 @@ def generate_yaml_config(
 
 
 def format_symbol_dump(
-    symbols: dict[Any, Sequence[AdsSymbol]],
+    symbols: dict[Any, dict[str, AdsSymbol]],
 ) -> str:
     """Format symbols for human-readable output.
 
     Args:
-        symbols: Dictionary of device_id -> list of AdsSymbol.
+        symbols: Dictionary of device_id -> (dict of symbol_name -> AdsSymbol).
 
     Returns:
         Formatted string representation of all symbols.
@@ -124,7 +123,7 @@ def format_symbol_dump(
         lines.append(f"\nDevice {device_id} ({len(device_symbols)} symbols):")
         lines.append("-" * 60)
 
-        for sym in device_symbols:
+        for sym in device_symbols.values():
             lines.append(f"  {sym.name}")
             lines.append(
                 f"    Group=0x{int(sym.group):08X}  Offset=0x{int(sym.offset):08X}  "
@@ -269,7 +268,7 @@ async def diagnose_hardware(
                             # Collect hardware symbol names
                             hardware_names = set()
                             for device_symbols in client._ecsymbols.values():
-                                for sym in device_symbols:
+                                for sym in device_symbols.values():
                                     hardware_names.add(sym.name)
 
                             # Collect simulator symbol names

--- a/tests/test_symbol_notifications.py
+++ b/tests/test_symbol_notifications.py
@@ -19,7 +19,7 @@ async def make_client() -> AsyncioADSClient:
 
 async def main():
     client = await make_client()
-    notif_symbols = []
+    notif_symbols = {}
 
     try:
         await client.introspect_io_server()
@@ -30,7 +30,7 @@ async def main():
         # notif_symbols = random.sample(symbols[master_dev], 800)
         print("...registering notifications...")
         await client.add_notifications(
-            notif_symbols,  # max_delay_ms=1000, cycle_time_ms=1000
+            list(notif_symbols.values()),  # max_delay_ms=1000, cycle_time_ms=1000
         )
         await asyncio.sleep(0.3)
 
@@ -49,7 +49,7 @@ async def main():
 
     finally:
         print("...deleting notifications...")
-        await client.delete_notifications(notif_symbols)
+        await client.delete_notifications(list(notif_symbols.values()))
         await asyncio.sleep(1)
 
         await client.close()

--- a/tests/test_symbol_readwrite.py
+++ b/tests/test_symbol_readwrite.py
@@ -28,11 +28,11 @@ async def main():
         # Read symbol values
         for _ in range(10):
             name, value = await client.read_ads_symbol(
-                random.choice(symbols[master_dev])
+                random.choice(list(symbols[master_dev].values()))
             )
             print(f"{name}: {value}")
 
-        read_symbols = random.sample(symbols[master_dev], 10)
+        read_symbols = random.sample(list(symbols[master_dev].values()), 10)
         for symbol in read_symbols:
             name, value = await client.read_ads_symbol(symbol)
             print(f"Read {name} = {value}")
@@ -42,12 +42,12 @@ async def main():
         # Write value to symbols
         output_symbols = [
             symbol
-            for symbol in symbols[master_dev]
+            for symbol in list(symbols[master_dev].values())
             if all(substr in symbol.name for substr in ["EL2024", "Channel"])
         ]
         if output_symbols:
             write_symbols = random.sample(
-                symbols[master_dev], min(10, len(output_symbols))
+                list(symbols[master_dev].values()), min(10, len(output_symbols))
             )
 
             for symbol in write_symbols:


### PR DESCRIPTION
this enables improved access to available symbols in get/set symbol functions
updated test files accordingly to match expected dictionary pattern